### PR TITLE
warning fix

### DIFF
--- a/assembly/malloc.ts
+++ b/assembly/malloc.ts
@@ -4,7 +4,7 @@ import {
 } from "rt/index-full";
 
 /// Allow host to allocate memory.
-export function malloc(size: usize): usize {
+export function malloc(size: i32): usize {
   let buffer = new ArrayBuffer(size);
   let ptr = changetype<usize>(buffer);
   return __retain(ptr);


### PR DESCRIPTION
Hi Yuval,

I'm from WalmartLabs and I'm helping on the research about using AssemblyScript to build an Envoy HTTP filter plugin.

I found this warning on the code when compiling my filter code, I thought you would like to take a look:

~/as/assembly
▶ npm run asbuild

> expo_envoy_filter_http@0.0.1 asbuild /Users/m0m02y0/as/assembly
> npm run asbuild:untouched && npm run asbuild:optimized


> expo_envoy_filter_http@0.0.1 asbuild:untouched /Users/m0m02y0/as/assembly
> asc assembly/index.ts -b build/untouched.wasm --use abort=abort_proc_exit -t build/untouched.wat --validate --sourceMap --debug

WARNING AS201: Conversion from type 'usize' to 'i32' will require an explicit cast when switching between 32/64-bit.

   let buffer = new ArrayBuffer(size);
                                ~~~~
 in ~lib/@solo-io/proxy-runtime/malloc.ts(8,31)


> expo_envoy_filter_http@0.0.1 asbuild:optimized /Users/m0m02y0/as/assembly
> asc assembly/index.ts -b build/optimized.wasm --use abort=abort_proc_exit -t build/optimized.wat --validate --sourceMap --optimize

WARNING AS201: Conversion from type 'usize' to 'i32' will require an explicit cast when switching between 32/64-bit.

   let buffer = new ArrayBuffer(size);
                                ~~~~
 in ~lib/@solo-io/proxy-runtime/malloc.ts(8,31)


