### PR TITLE
warning-fix2

### DIFF
--- a/assembly/runtime.ts
+++ b/assembly/runtime.ts
@@ -225,7 +225,7 @@ export function set_property(path: string, data: ArrayBuffer): WasmResultValues 
   return imports.proxy_set_property(changetype<usize>(buffer), buffer.byteLength, changetype<usize>(data), data.byteLength);
 }
 
-function pairsSize(headers: Headers): usize {
+function pairsSize(headers: Headers): i32 {
   let size = 4; // number of headers
   // for in loop doesn't seem to be supported..
   for (let i = 0; i < headers.length; i++) {


### PR DESCRIPTION
Hey @yuval-k,

Just another small type conversion warning fix.

```
> asc assembly/index.ts -b build/untouched.wasm --use abort=abort_proc_exit -t build/untouched.wat --validate --sourceMap --debug

WARNING AS201: Conversion from type 'usize' to 'i32' will require an explicit cast when switching between 32/64-bit.

   let result = new ArrayBuffer(pairsSize(headers));
                                ~~~~~~~~~~~~~~~~~~
 in ~lib/@solo-io/proxy-runtime/runtime.ts(241,31)
```