### PR TITLE
proxy_set_buffer_status is not part of any ABI version, so remove it.

### DIFF
--- a/assembly/imports.ts
+++ b/assembly/imports.ts
@@ -125,10 +125,6 @@ export declare function proxy_get_buffer_bytes(typ: BufferType, start: u32, leng
 @external("env", "proxy_get_buffer_status")
 export declare function proxy_get_buffer_status(typ: BufferType, length_ptr: ptr<usize>, flags_ptr: ptr<u32>): WasmResult;
 
-// @ts-ignore: decorator
-@external("env", "proxy_get_buffer_status")
-export declare function proxy_set_buffer_status(typ: BufferType, start: u32, length: u32, data: ptr<char>, size: size_t): WasmResult;
-
 // HTTP
 // @ts-ignore: decorator
 @external("env", "proxy_http_call")


### PR DESCRIPTION
If we were to leave it here, the @external label would need to change because
it is currently duplicated with the getter (i.e, `@external("env", "proxy_get_buffer_status")`). (It is the only one like that.)