### PR TITLE
tsconfig assemblyscript reference fix

### DIFF
--- a/examples/addheader/assembly/tsconfig.json
+++ b/examples/addheader/assembly/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../node_modules/assemblyscript/std/assembly.json",
+  "extends": "../node_modules/assemblyscript/std/assembly.json",
   "include": [
     "./**/*.ts"
   ]

--- a/examples/auth/assembly/tsconfig.json
+++ b/examples/auth/assembly/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../node_modules/assemblyscript/std/assembly.json",
+  "extends": "../node_modules/assemblyscript/std/assembly.json",
   "include": [
     "./**/*.ts"
   ]

--- a/examples/singleton/assembly/tsconfig.json
+++ b/examples/singleton/assembly/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../node_modules/assemblyscript/std/assembly.json",
+  "extends": "../node_modules/assemblyscript/std/assembly.json",
   "include": [
     "./**/*.ts"
   ]


### PR DESCRIPTION
This fix will ensure we're correctly referencing `node_modules` directory for the given example.