### PR TITLE
Add call_foreign_function

### DIFF
--- a/assembly/index.ts
+++ b/assembly/index.ts
@@ -10,5 +10,5 @@ export {
     Gauge, Histogram, Counter, log,
     HttpCallback, send_local_response, continue_request, continue_response, 
     proxy_set_effective_context, set_property, get_property, get_shared_data, set_shared_data, set_tick_period_milliseconds,
-    get_buffer_bytes
+    get_buffer_bytes, call_foreign_function
 } from "./runtime";

--- a/assembly/runtime.ts
+++ b/assembly/runtime.ts
@@ -706,6 +706,25 @@ export function proxy_set_effective_context(_id: u32): WasmResultValues {
   }
   return result;
 }
+
+/**
+ * Call foreign function with the specified name and argument
+ * @param function_name the function name
+ * @param argument the parameters
+ */
+export function call_foreign_function(function_name: string, argument: string): ArrayBuffer {
+  let function_name_buffer = String.UTF8.encode(function_name);
+  let argument_name_buffer = String.UTF8.encode(argument);
+
+  CHECK_RESULT(imports.proxy_call_foreign_function(
+      changetype<usize>(function_name_buffer),
+      function_name_buffer.byteLength,
+      changetype<usize>(argument_name_buffer),
+      argument_name_buffer.byteLength,
+      globalArrayBufferReference.bufferPtr(),
+      globalArrayBufferReference.sizePtr()));
+  return globalArrayBufferReference.toArrayBuffer();
+}
 /////// runtime support
 
 /**


### PR DESCRIPTION
Users should be able to call [foreign functions](https://github.com/proxy-wasm/spec/blob/master/abi-versions/vNEXT/README.md#proxy_call_foreign_function) to interact with the host.