### PR TITLE
Enable shared_queue proxy calls

### DIFF
--- a/assembly/index.ts
+++ b/assembly/index.ts
@@ -10,5 +10,6 @@ export {
     Gauge, Histogram, Counter, log,
     HttpCallback, send_local_response, continue_request, continue_response, 
     proxy_set_effective_context, set_property, get_property, get_shared_data, set_shared_data, set_tick_period_milliseconds,
+    register_shared_queue, resolve_shared_queue, enqueue_shared_queue, dequeue_shared_queue,
     get_buffer_bytes, call_foreign_function
 } from "./runtime";


### PR DESCRIPTION
Enable shared_queue proxy calls

Changes:
* Added to exports list.
* Fetch token using u32Ref.
* Return token and call result in a struct, following similar pattern to other calls.

I have tested this change in Envoy, passing messages between two extensions.