### PR TITLE
Fix empty config throwing error

### DIFF
--- a/assembly/runtime.ts
+++ b/assembly/runtime.ts
@@ -856,6 +856,10 @@ export class RootContext extends BaseContext {
   // Returns false if the configuration is invalid.
   onConfigure(configuration_size: u32): bool {
     log(LogLevelValues.debug, "context id: " + this.context_id.toString() + ": onConfigure(configuration_size: " + configuration_size.toString() + ")");
+    if (configuration_size == 0) {
+      // No config
+      return true
+    }
     CHECK_RESULT(imports.proxy_get_buffer_bytes(BufferTypeValues.PluginConfiguration, 0, configuration_size, globalArrayBufferReference.bufferPtr(), configuration_size));
     this.configuration_ = String.UTF8.decode(globalArrayBufferReference.toArrayBuffer());
     log(LogLevelValues.debug, "context id: " + this.context_id.toString() + ": Updating this.configuration=" + this.configuration_);

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "name": "@solo-io/proxy-runtime",
   "description": "Use this SDK to write extensions for the proxy WASM ABI",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "main": "assembly/index.ts",
   "directories": {
     "doc": "docs"


### PR DESCRIPTION
Fixes a bug where empty configuration resulted in an
error with the default onConfigure() method.

Error seen was:
```
wasm log my_filter_id: Object is not pinned at: ~lib/rt/itcms.ts(351:5)
```